### PR TITLE
Fixed compatibility issue with kdyby/doctrine v3

### DIFF
--- a/src/Entities/Attributes/Translatable.php
+++ b/src/Entities/Attributes/Translatable.php
@@ -33,6 +33,11 @@ trait Translatable
 			return $value;
 		}
 
+		if (method_exists($this, $methodName)) {
+			$value = $this->$methodName();
+			return $value;
+		}
+
 		return $this->$name;
 	}
 


### PR DESCRIPTION
After update to kdyby/doctrine v3.0.1 from kdyby/doctrine v2.3.1, was getting an Doctrine\ORM\ORMException error when trying to access private Entity property, e.g. IdentifiedEntity::$id.