### PR TITLE
Fix timestampable extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 	"require": {
 		"php": ">=5.6",
 		"kdyby/events": "~2.3|~3.0",
-		"knplabs/doctrine-behaviors": "~1.2.0",
+		"knplabs/doctrine-behaviors": "~1.2",
 		"tracy/tracy": "~2.3"
 	},
 	"require-dev": {

--- a/src/DI/TimestampableExtension.php
+++ b/src/DI/TimestampableExtension.php
@@ -22,7 +22,8 @@ final class TimestampableExtension extends AbstractBehaviorExtension
 	 */
 	private $default = [
 		'isRecursive' => TRUE,
-		'trait' => Timestampable::class
+		'trait' => Timestampable::class,
+		'dbFieldType' => 'datetime',
 	];
 
 
@@ -36,7 +37,8 @@ final class TimestampableExtension extends AbstractBehaviorExtension
 			->setClass(TimestampableSubscriber::class, [
 				'@' . $this->getClassAnalyzer()->getClass(),
 				$config['isRecursive'],
-				$config['trait']
+				$config['trait'],
+				$config['dbFieldType'],
 			])
 			->setAutowired(FALSE)
 			->addTag(EventsExtension::TAG_SUBSCRIBER);
@@ -50,6 +52,7 @@ final class TimestampableExtension extends AbstractBehaviorExtension
 	{
 		Validators::assertField($config, 'isRecursive', 'bool');
 		Validators::assertField($config, 'trait', 'type');
+		Validators::assertField($config, 'dbFieldType', 'string');
 	}
 
 }


### PR DESCRIPTION
Hi, 

in latest KnpLabs/DoctrineBehaviors package is new required option called 'db_field_type'.

See [KNP documentation](https://github.com/KnpLabs/DoctrineBehaviors#timestampable).

Thanks!