### PR TITLE
Fixed compatibility problems with new version of knplabs/doctrine-behaviors.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 	"require": {
 		"php": ">=5.6",
 		"kdyby/events": "~2.3|~3.0",
-		"knplabs/doctrine-behaviors": "~1.2",
+		"knplabs/doctrine-behaviors": "~1.2.0",
 		"tracy/tracy": "~2.3"
 	},
 	"require-dev": {


### PR DESCRIPTION
This package is not compatible with knplabs/doctrine-behaviors 1.3.0, quick fix is to stop requiring it.