### PR TITLE
TranslatableExtension: fix assertField parameter

### DIFF
--- a/src/DI/TranslatableExtension.php
+++ b/src/DI/TranslatableExtension.php
@@ -61,7 +61,7 @@ final class TranslatableExtension extends AbstractBehaviorExtension
 	 */
 	private function validateConfigTypes(array $config)
 	{
-		Validators::assertField($config, 'currentLocaleCallable', NULL | 'array');
+		Validators::assertField($config, 'currentLocaleCallable', 'null|array');
 		Validators::assertField($config, 'translatableTrait', 'type');
 		Validators::assertField($config, 'translationTrait', 'type');
 		Validators::assertField($config, 'translatableFetchMode', 'string');


### PR DESCRIPTION
Based on https://github.com/nette/utils/blob/master/tests/Utils/Validators.assert().phpt I suppose the parameter was not passed correctly. 
Causes problem on PHP 7.1 generating `Warning: A non-numeric value encountered`.