### PR TITLE
GeocodableExtension: fix assertField parameter

### DIFF
--- a/src/DI/GeocodableExtension.php
+++ b/src/DI/GeocodableExtension.php
@@ -57,7 +57,7 @@ final class GeocodableExtension extends AbstractBehaviorExtension
 	{
 		Validators::assertField($config, 'isRecursive', 'bool');
 		Validators::assertField($config, 'trait', 'type');
-		Validators::assertField($config, 'geolocationCallable', NULL | 'type');
+		Validators::assertField($config, 'geolocationCallable', 'null|type');
 	}
 
 }


### PR DESCRIPTION
I noticed that phpunit pops warning for GeocodableExtension as well so there's PR for this too.